### PR TITLE
Fixing the style names for animations & transitions.

### DIFF
--- a/src/lightbox-overlay.component.ts
+++ b/src/lightbox-overlay.component.ts
@@ -41,7 +41,7 @@ export class LightboxOverlayComponent implements AfterViewInit, OnDestroy {
     this._rendererRef.setElementStyle(this._elemRef.nativeElement,
       '-webkit-animation-duration', `${fadeDuration}s`);
     this._rendererRef.setElementStyle(this._elemRef.nativeElement,
-      '-animation-duration', `${fadeDuration}s`);
+      'animation-duration', `${fadeDuration}s`);
     this._sizeOverlay();
   }
 

--- a/src/lightbox.component.ts
+++ b/src/lightbox.component.ts
@@ -336,27 +336,27 @@ export class LightboxComponent implements AfterViewInit, OnDestroy {
     this._rendererRef.setElementStyle(this._lightboxElem.nativeElement,
       '-webkit-animation-duration', `${fadeDuration}s`);
     this._rendererRef.setElementStyle(this._lightboxElem.nativeElement,
-      '-animation-duration', `${fadeDuration}s`);
+      'animation-duration', `${fadeDuration}s`);
     this._rendererRef.setElementStyle(this._outerContainerElem.nativeElement,
       '-webkit-transition-duration', `${resizeDuration}s`);
     this._rendererRef.setElementStyle(this._outerContainerElem.nativeElement,
-      '-transition-duration', `${resizeDuration}s`);
+      'transition-duration', `${resizeDuration}s`);
     this._rendererRef.setElementStyle(this._dataContainerElem.nativeElement,
       '-webkit-animation-duration', `${fadeDuration}s`);
     this._rendererRef.setElementStyle(this._dataContainerElem.nativeElement,
-      '-animation-duration', `${fadeDuration}s`);
+      'animation-duration', `${fadeDuration}s`);
     this._rendererRef.setElementStyle(this._imageElem.nativeElement,
       '-webkit-animation-duration', `${fadeDuration}s`);
     this._rendererRef.setElementStyle(this._imageElem.nativeElement,
-      '-animation-duration', `${fadeDuration}s`);
+      'animation-duration', `${fadeDuration}s`);
     this._rendererRef.setElementStyle(this._captionElem.nativeElement,
       '-webkit-animation-duration', `${fadeDuration}s`);
     this._rendererRef.setElementStyle(this._captionElem.nativeElement,
-      '-animation-duration', `${fadeDuration}s`);
+      'animation-duration', `${fadeDuration}s`);
     this._rendererRef.setElementStyle(this._numberElem.nativeElement,
       '-webkit-animation-duration', `${fadeDuration}s`);
     this._rendererRef.setElementStyle(this._numberElem.nativeElement,
-      '-animation-duration', `${fadeDuration}s`);
+      'animation-duration', `${fadeDuration}s`);
   }
 
   private _end(): void {


### PR DESCRIPTION
Due to these, the library was not showing the images in IE. The animation/transition was not working in IE. The transition needed to work and finish in order to run _postResize() method upon 'transitionend' event.