### PR TITLE
Fix build errors when noUnusedLocals is true

### DIFF
--- a/src/lightbox.component.ts
+++ b/src/lightbox.component.ts
@@ -5,14 +5,11 @@ import {
   Inject,
   Input,
   OnDestroy,
-  OnChanges,
   Renderer,
-  SimpleChange,
   ViewChild
 } from '@angular/core';
 import { DOCUMENT } from '@angular/platform-browser';
 import { LightboxEvent, LIGHTBOX_EVENT, IAlbum, IEvent, LightboxWindowRef } from './lightbox-event.service';
-import { Subscription } from 'rxjs/Subscription';
 
 @Component({
   template: `

--- a/src/lightbox.module.ts
+++ b/src/lightbox.module.ts
@@ -1,4 +1,3 @@
-import { BrowserModule } from '@angular/platform-browser';
 import { Lightbox } from './lightbox.service';
 import { LightboxComponent } from './lightbox.component';
 import { LightboxConfig } from './lightbox-config.service';


### PR DESCRIPTION
When noUnusedLocals is set to true in your project, you get the following build errors:

ERROR in node_modules/angular2-lightbox/lightbox.component.ts(8,3): error TS6133: 'OnChanges' is declared but never used.
node_modules/angular2-lightbox/lightbox.component.ts(10,3): error TS6133: 'SimpleChange' is declared but never used.
node_modules/angular2-lightbox/lightbox.component.ts(15,10): error TS6133: 'Subscription' is declared but never used.
node_modules/angular2-lightbox/lightbox.module.ts(1,10): error TS6133: 'BrowserModule' is declared but never used.

So i just cleaned up those unused imports. I did not set it in your tsconfig, but it might be  good idea to add it.