### PR TITLE
fix bug images not shown in case two images size are almost same.

### DIFF
--- a/src/lightbox.component.ts
+++ b/src/lightbox.component.ts
@@ -255,8 +255,8 @@ export class LightboxComponent implements AfterViewInit, OnDestroy {
       this._cssValue.imageBorderWidthLeft + this._cssValue.imageBorderWidthRight;
     const newHeight = imageHeight + this._cssValue.containerTopPadding + this._cssValue.containerBottomPadding +
       this._cssValue.imageBorderWidthTop + this._cssValue.imageBorderWidthBottom;
-
-    if (oldWidth !== newWidth || oldHeight !== newHeight) {
+    // make sure that distances are large enough for transitionend event to be fired, at least 5px.
+    if (Math.abs(oldWidth - newWidth) + Math.abs(oldHeight - newHeight) > 5) {
       this._rendererRef.setElementStyle(this._outerContainerElem.nativeElement, 'width', `${newWidth}px`);
       this._rendererRef.setElementStyle(this._outerContainerElem.nativeElement, 'height', `${newHeight}px`);
 


### PR DESCRIPTION
Hello world.

Recently I have a project that use angular2-lightbox, but there is one problem is my images are almost same size but a little bit different about some pixels, in that case when user click on the "Next" button the lightbix is getting freeze and the loader spinning forever.

I was debug and found the problem was the "transitionend" is not fired because the images size that I mentioned above. I have fixed this issue and want to make a pull request for any one have same problem.

Thank you.