### PR TITLE
#32 - sanitize the 'src' url to correctly work with blob object url

### DIFF
--- a/src/lightbox.component.ts
+++ b/src/lightbox.component.ts
@@ -6,9 +6,10 @@ import {
   Input,
   OnDestroy,
   Renderer,
-  ViewChild
+  SecurityContext,
+  ViewChild,
 } from '@angular/core';
-import { DOCUMENT } from '@angular/platform-browser';
+import { DOCUMENT, DomSanitizer } from '@angular/platform-browser';
 import { LightboxEvent, LIGHTBOX_EVENT, IAlbum, IEvent, LightboxWindowRef } from './lightbox-event.service';
 
 @Component({
@@ -67,6 +68,7 @@ export class LightboxComponent implements AfterViewInit, OnDestroy {
     private _lightboxEvent: LightboxEvent,
     public _lightboxElem: ElementRef,
     private _lightboxWindowRef: LightboxWindowRef,
+    private _sanitizer: DomSanitizer,
     @Inject(DOCUMENT) private _documentRef: any
   ) {
     // initialize data
@@ -198,7 +200,9 @@ export class LightboxComponent implements AfterViewInit, OnDestroy {
     preloader.onload = () => {
       this._onLoadImageSuccess();
     }
-    preloader.src = this.album[this.currentImageIndex].src;
+
+    const src: any = this.album[this.currentImageIndex].src;
+    preloader.src = this._sanitizer.sanitize(SecurityContext.URL, src);
   }
 
   /**
@@ -249,9 +253,9 @@ export class LightboxComponent implements AfterViewInit, OnDestroy {
   }
 
   private _sizeContainer(imageWidth: number, imageHeight: number): void {
-    const oldWidth  = this._outerContainerElem.nativeElement.offsetWidth;
+    const oldWidth = this._outerContainerElem.nativeElement.offsetWidth;
     const oldHeight = this._outerContainerElem.nativeElement.offsetHeight;
-    const newWidth  = imageWidth + this._cssValue.containerRightPadding + this._cssValue.containerLeftPadding +
+    const newWidth = imageWidth + this._cssValue.containerRightPadding + this._cssValue.containerLeftPadding +
       this._cssValue.imageBorderWidthLeft + this._cssValue.imageBorderWidthRight;
     const newHeight = imageHeight + this._cssValue.containerTopPadding + this._cssValue.containerBottomPadding +
       this._cssValue.imageBorderWidthTop + this._cssValue.imageBorderWidthBottom;
@@ -508,9 +512,9 @@ export class LightboxComponent implements AfterViewInit, OnDestroy {
     switch (event.id) {
       case LIGHTBOX_EVENT.CLOSE:
         this._end();
-      break;
+        break;
       default:
-      break;
+        break;
     }
   }
 }


### PR DESCRIPTION
I propose you this PR to be able to accept blob object url and avoid the error similar to this:

`SafeValue%20must%20use%20[property]=binding:%20blob:http://localhost...`

My change refers to the `preloader.src` property.

### PREFACE
Object URL, in Angular, is accepted only when used directly as a [property] binding in html code.
The `album[this.currentImageIndex].src`, when populated with a blob object URL, contains a `SafeValueImpl` object containing the objectURL. 
When this 'src' is used in code-behind (in our case to populate the `preloader.src`) the SafeValueImpl returns the objectURL with this initial string: `SafeValue%20must%20use%20[property]=binding:%20` 

### SOLUTION
The preloader source Image needs a sanitization of `album[this.currentImageIndex].src`
This sanitization makes more strong and secure the code and gets the objectURL as a correctly string. It is also fully compatible with a "simple" 'src' containing a classic URL (like in your demo)

Please consider this PR as soon as possible releasing an hotfix. 
This will be great for me to continue to use your great product!

PS: in this PR there is also some minor formatting changes that my VS Code done automatically on saving. Hope this doesn't hurt you.